### PR TITLE
Update car card navigation to open in new tab with redirect

### DIFF
--- a/app/components/CarCard.vue
+++ b/app/components/CarCard.vue
@@ -1,5 +1,10 @@
 <template>
-  <div class="car-card" @click="navigateTo(`/cars/${car.id}`)">
+  <div class="car-card" @click="navigateTo(`/cars/${car.id}`, {
+    external: true,
+    open: {
+      target: '_blank',
+    }
+  })">
     <!-- Image area -->
     <div class="car-img-area">
       <div v-if="car.images && car.images.length" class="car-img-placeholder">

--- a/app/pages/cars/[id].vue
+++ b/app/pages/cars/[id].vue
@@ -1,0 +1,14 @@
+<template>
+  <div>
+    Redirecting you to Qatar Living...
+  </div>
+</template>
+
+<script lang="ts" setup>
+const $route = useRoute();
+navigateTo(`https://www.qatarliving.com/en/vehicles/cars/${$route.params.id}`, {
+  external: true
+});
+</script>
+
+<style></style>


### PR DESCRIPTION
This pull request updates how users are redirected when interacting with car listings, ensuring that car detail links open in a new tab and that direct navigation to a car's detail page redirects users to an external site.

**Improvements to navigation and user experience:**

* Updated the `CarCard.vue` component so that clicking a car card opens the car detail page in a new browser tab by passing the appropriate options to `navigateTo`.
* Added a new template to `pages/cars/[id].vue` that automatically redirects users to the corresponding external Qatar Living car detail page when accessed directly, displaying a brief redirect message. ([app/pages/cars/[id].vueR1-R14](diffhunk://#diff-3267b6ce176d6754685e9af5aa8f48755d85b59f10a55c88829ac60fe4cf0ae6R1-R14))