### PR TITLE
Limit page fetching to 5 and enhance car card navigation

### DIFF
--- a/app/components/CarCard.vue
+++ b/app/components/CarCard.vue
@@ -1,5 +1,10 @@
 <template>
-  <div class="car-card" @click="navigateTo(`/cars/${car.id}`)">
+  <div class="car-card" @click="navigateTo(`/cars/${car.id}`, {
+    external: true,
+    open: {
+      target: '_blank',
+    }
+  })">
     <!-- Image area -->
     <div class="car-img-area">
       <div v-if="car.images && car.images.length" class="car-img-placeholder">

--- a/app/pages/cars/[id].vue
+++ b/app/pages/cars/[id].vue
@@ -1,0 +1,14 @@
+<template>
+  <div>
+    Redirecting you to Qatar Living...
+  </div>
+</template>
+
+<script lang="ts" setup>
+const $route = useRoute();
+navigateTo(`https://www.qatarliving.com/en/vehicles/cars/${$route.params.id}`, {
+  external: true
+});
+</script>
+
+<style></style>

--- a/populate-db.js
+++ b/populate-db.js
@@ -102,7 +102,7 @@ try {
   });
   await processData(data.adsCar);
 
-  for (let i = 2; i <= data.meta.totalPages; i++) {
+  for (let i = 2; i <= 5; i++) { // data.meta.totalPages to fetch all pages
     console.log(`Fetching page ${i}...`);
     res = await fetch(`https://bo-prod.qatarliving.com/vehicles?cur_page=${i}&per_page=50`);
     data = await res.json();


### PR DESCRIPTION
This pull request introduces improvements to the car listing and detail navigation experience, as well as an update to the database population script. The most significant changes are the addition of a redirect page for car details, updates to how car cards handle navigation, and a modification to the data fetching loop in the database script.

Navigation and user experience improvements:

* Added a new `[id].vue` page under `app/pages/cars/` that automatically redirects users to the corresponding Qatar Living car detail page, displaying a "Redirecting you to Qatar Living..." message during the process. ([app/pages/cars/[id].vueR1-R14](diffhunk://#diff-3267b6ce176d6754685e9af5aa8f48755d85b59f10a55c88829ac60fe4cf0ae6R1-R14))
* Updated the `CarCard.vue` component so that clicking a car card now opens the car detail page in a new browser tab using the `target: '_blank'` option.

Database script update:

* In `populate-db.js`, changed the data fetching loop to only fetch up to page 5 instead of all available pages, likely to limit the amount of data processed during database population.